### PR TITLE
Sanitize table HTML

### DIFF
--- a/app.js
+++ b/app.js
@@ -621,8 +621,8 @@ function renderSliderTable() {
         
         tableHTML += `
             <tr>
-                <td>${customerName}</td>
-                <td>${lcsm}</td>
+                <td>${AppUtils.escapeHTML(customerName)}</td>
+                <td>${AppUtils.escapeHTML(lcsm)}</td>
                 <td>€${arr.toLocaleString()}</td>
                 <td>${risk.toFixed(1)}</td>
                 <td>
@@ -912,9 +912,10 @@ function renderTable(data) {
                 tableHTML += `<td>€${arr.toLocaleString()}</td>`;
             } else if (col === 'Customer Name') {
                 const customerName = row['Customer Name'] || row['Kunde'] || row['Kundenname'] || row['Customer'] || row['Name'] || 'Unknown';
-                tableHTML += `<td>${customerName}</td>`;
+                tableHTML += `<td>${AppUtils.escapeHTML(customerName)}</td>`;
             } else {
-                tableHTML += `<td>${row[col] || ''}</td>`;
+                const cellValue = row[col] || '';
+                tableHTML += `<td>${AppUtils.escapeHTML(cellValue)}</td>`;
             }
         });
         tableHTML += '</tr>';

--- a/riskmap.html
+++ b/riskmap.html
@@ -1019,8 +1019,8 @@
                 
                 tableHTML += `
                     <tr>
-                        <td>${customerName}</td>
-                        <td>${lcsm}</td>
+                        <td>${AppUtils.escapeHTML(customerName)}</td>
+                        <td>${AppUtils.escapeHTML(lcsm)}</td>
                         <td>€${arr.toLocaleString()}</td>
                         <td>${risk.toFixed(1)}</td>
                         <td>

--- a/utils.js
+++ b/utils.js
@@ -48,6 +48,12 @@ function throttle(fn, limit = 300) {
     };
 }
 
+function escapeHTML(str) {
+    const div = document.createElement('div');
+    div.textContent = str == null ? '' : String(str);
+    return div.innerHTML;
+}
+
 // =============================================================================
 // GLOBALER NAMESPACE (OHNE ES6 EXPORTS)
 // =============================================================================
@@ -60,6 +66,8 @@ window.AppUtils = {
         'Total Risk': ['Total Risk', 'total risk', 'TOTAL RISK', 'TotalRisk', 'totalrisk', 'TOTALRISK', 'Risk', 'risk', 'RISK', 'Risiko', 'risiko', 'RISIKO', 'Score', 'score', 'SCORE', 'Risk Score', 'risk score', 'RISK SCORE', 'RiskScore', 'riskscore', 'RISKSCORE'],
         'ARR': ['ARR', 'arr', 'Arr', 'Annual Recurring Revenue', 'annual recurring revenue', 'ANNUAL RECURRING REVENUE', 'Revenue', 'revenue', 'REVENUE', 'Umsatz', 'umsatz', 'UMSATZ', 'Vertragswert', 'vertragswert', 'VERTRAGSWERT', 'Value', 'value', 'VALUE', 'Wert', 'wert', 'WERT', 'Amount', 'amount', 'AMOUNT']
     },
+
+    escapeHTML: escapeHTML,
 
     // KORRIGIERT: IDENTISCHE Spaltenerkennung wie in app.js und riskmap.html
     findColumnName: function(headers, targetColumn) {


### PR DESCRIPTION
## Summary
- add `escapeHTML` helper in utils.js and expose via `AppUtils`
- use escaped values when inserting customer data into tables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841e264ef648323b3676d87c802a0af