### PR TITLE
Add KPI dashboard and FAQ modal

### DIFF
--- a/app.html
+++ b/app.html
@@ -9,6 +9,7 @@
     
     <!-- Lade utils.js ZUERST, dann app.js -->
     <script src="utils.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="app.js"></script>
 </head>
 <body>
@@ -31,6 +32,7 @@
                     <li><button class="sidebar-btn" id="uploadDataBtn">Upload Data</button></li>
                     <li><button class="sidebar-btn" id="heatmapBtn">📊 RiskMap</button></li>
                     <li><button class="sidebar-btn" id="archiveBtn">📋 Archive</button></li>
+                    <li><button class="sidebar-btn" id="kpiDashboardBtn">📈 KPI Dashboard</button></li>
                 </ul>
             </nav>
             
@@ -72,10 +74,14 @@
                 <h2 id="sliderTitle">RISKMAP</h2>
                 <button id="closeSliderBtn" class="close-slider-btn">×</button>
             </div>
-            
+
             <div class="slider-content" id="sliderContent">
                 <!-- Content wird dynamisch geladen -->
             </div>
+        </div>
+
+        <div id="kpiDashboardContainer" style="display:none;">
+          <!-- Charts and filters will be injected here -->
         </div>
     </div>
 
@@ -83,6 +89,14 @@
     <div class="footer-transparent" id="footerTransparent">
         <div class="footer-content-transparent">
             <a href="https://github.com/Olivetr33/No-More-Risk-" target="_blank" rel="noopener" class="github-link">GitHub</a>
+            <button class="faq-footer-btn" id="faqBtn">❓ FAQ</button>
+        </div>
+    </div>
+
+    <div id="faqPopupBg" class="popup-bg" style="display:none;">
+        <div class="popup" id="faqPopup">
+            <button class="popup-close" onclick="hideFaqModal()" title="Close" aria-label="Close popup">×</button>
+            <div id="faqPopupInner"></div>
         </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -658,4 +658,63 @@ body {
   }
 }
 
+.kpi-dashboard-card {
+  background: var(--color-card);
+  padding: 20px;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  margin-bottom: 40px;
+}
+
+.chart-container {
+  position: relative;
+  width: 100%;
+  margin-top: 20px;
+}
+
+.dashboard-export-btn {
+  background: var(--color-accent);
+  color: var(--color-text-dark);
+  border: none;
+  border-radius: var(--mini-radius);
+  padding: 10px 20px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.dashboard-export-btn:hover {
+  filter: drop-shadow(0 0 8px rgba(255,210,33,0.6));
+}
+
+.faq-footer-btn {
+  background: none;
+  color: #ffffff;
+  border: 1px solid rgba(255,255,255,0.3);
+  border-radius: 25px;
+  padding: 12px 24px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.faq-footer-btn:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: rgba(255,255,255,0.6);
+  transform: translateY(-2px);
+}
+
+.chartjs-tooltip {
+  background: var(--color-card) !important;
+  border: 1px solid var(--color-accent) !important;
+  color: var(--color-text) !important;
+  border-radius: 6px !important;
+  padding: 8px 12px !important;
+}
+
+.chartjs-legend li {
+  color: var(--color-text) !important;
+}
+
 ::-webkit-scrollbar { width: 0; background: transparent; }


### PR DESCRIPTION
## Summary
- add KPI Dashboard sidebar button and container
- include Chart.js and create FAQ modal popup
- implement KPI chart rendering and risk history chart
- extend utils with risk history helpers and chart export
- style new dashboard elements and footer button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68420ca9ae488323a5b453c2be119779