### PR TITLE
Add workflow panel and KPI fixes

### DIFF
--- a/app.html
+++ b/app.html
@@ -33,6 +33,7 @@
                     <li><button class="sidebar-btn" id="heatmapBtn">📊 RiskMap</button></li>
                     <li><button class="sidebar-btn" id="archiveBtn">📋 Archive</button></li>
                     <li><button class="sidebar-btn" id="kpiDashboardBtn">📈 KPI Dashboard</button></li>
+                    <li><button class="sidebar-btn" id="workflowBtn">🗂 Workflow</button></li>
                 </ul>
             </nav>
             
@@ -78,6 +79,11 @@
             <div class="slider-content" id="sliderContent">
                 <!-- Content wird dynamisch geladen -->
             </div>
+        </div>
+
+        <div id="workflowSidebar" class="sidebar-slider">
+          <h2>Please contact the following Customers soon</h2>
+          <table class="workflow-table"></table>
         </div>
 
         <div id="kpiDashboardContainer" style="display:none;">
@@ -639,6 +645,43 @@
             border-color: rgba(255, 255, 255, 0.6);
             transform: translateY(-2px);
         }
+
+        #kpiDashboardContainer {
+            position: relative;
+            z-index: 10;
+            margin-left: 220px;
+            padding: 20px;
+            background-color: #181a1b;
+            min-height: 100vh;
+        }
+
+        #kpiDashboardContainer .chart-container {
+            width: 100%;
+            max-width: 100%;
+            overflow-x: auto;
+        }
+        #kpiDashboardContainer canvas {
+            width: 100% !important;
+            height: auto !important;
+        }
+
+        .sidebar-slider {
+            position: fixed;
+            top: 0;
+            right: -50vw;
+            width: 50vw;
+            height: 100vh;
+            background: #23272b;
+            overflow-y: auto;
+            z-index: 2100;
+            transition: right 0.5s ease;
+            padding: 20px;
+            box-shadow: -3px 0 10px rgba(0,0,0,0.5);
+        }
+        .sidebar-slider.active { right: 0; }
+        .workflow-table { width: 100%; border-collapse: collapse; color: #fff; }
+        .workflow-table th, .workflow-table td { padding: 8px; border-bottom: 1px solid rgba(255,255,255,0.1); }
+        .workflow-add-btn { background: #ffd221; color: #000; border: none; border-radius: 6px; padding: 4px 8px; cursor: pointer; margin-left:4px; }
 
         /* Responsive Design */
         @media (max-width: 768px) {

--- a/riskmap.html
+++ b/riskmap.html
@@ -656,6 +656,19 @@
             overflow-y: auto;
             box-shadow: 0 4px 32px rgba(0,0,0,0.3);
         }
+        #radarPopup { justify-content: flex-end; }
+        .radar-panel {
+            position: fixed;
+            top: 0;
+            right: 0;
+            width: 50vw;
+            height: 100vh;
+            background-color: #23272b;
+            overflow-y: auto;
+            z-index: 100;
+            padding: 20px;
+            box-shadow: -3px 0 10px rgba(0,0,0,0.5);
+        }
 
         .radar-details-table {
             width: 100%;
@@ -684,6 +697,10 @@
         }
         .radar-actions .archive-btn { background: #4CAF50; color: #fff; }
         .radar-actions .todo-btn { background: #2196F3; color: #fff; }
+        .workflow-add-btn {
+            background: #ffd221;
+            color: #000;
+        }
         .radar-close {
             margin-top: 12px;
             padding: 6px 14px;
@@ -1099,6 +1116,7 @@
                                 padding: 6px 12px; background: #4CAF50; color: white;
                                 border: none; border-radius: 6px; cursor: pointer; font-size: 12px;"
                                 title="Archive this entry">Archive</button>
+                            <button class="workflow-add-btn" onclick="addToWorkflowRiskmap(${index})" title="Add to Workflow">+ Add</button>
                         </td>
                     </tr>
                 `;
@@ -1236,6 +1254,44 @@
                     }, 300);
                 }
             }, 3000);
+        }
+
+        function addToWorkflowRiskmap(index){
+            if(index < 0 || index >= riskmapData.length) return;
+            const c = riskmapData[index];
+            const name = c['Customer Name'] || c['Kunde'] || c['Name'] || `Customer ${index+1}`;
+            const lcsm = c['LCSM'] || c['lcsm'] || '';
+            const arr = parseFloat(c['ARR'] || c['arr'] || 0).toFixed(2);
+            const key = [name, lcsm, arr].join('|');
+            const entry = {name, lcsms: lcsm, totalRisk: parseFloat(c['Total Risk'] || c['risk'] || 0), addedAt: new Date().toISOString()};
+            const keys = ['riskerSessionData','sessionData','appData'];
+            keys.forEach(k=>{
+                let sd = JSON.parse(localStorage.getItem(k) || '{}');
+                if(!sd.workflowEntries) sd.workflowEntries = {};
+                sd.workflowEntries[key] = entry;
+                localStorage.setItem(k, JSON.stringify(sd));
+            });
+            showNotification(`${name} added to workflow`);
+        }
+
+        function addToWorkflowRadar(idx){
+            const data = getRadarData();
+            const row = data[idx];
+            if(!row) return;
+            const name = getField(row, ['Customer Name','Kunde','Name']) || `Customer ${idx+1}`;
+            const lcsm = getField(row, ['LCSM','CSM','Manager']) || '';
+            const arr = parseFloat(getField(row, ['ARR','Revenue','Umsatz']) || 0).toFixed(2);
+            const risk = parseFloat(getField(row, ['Total Risk','Risk']) || 0);
+            const key = [name, lcsm, arr].join('|');
+            const entry = {name, lcsms: lcsm, totalRisk: risk, addedAt: new Date().toISOString()};
+            const keys = ['riskerSessionData','sessionData','appData'];
+            keys.forEach(k=>{
+                let sd = JSON.parse(localStorage.getItem(k) || '{}');
+                if(!sd.workflowEntries) sd.workflowEntries = {};
+                sd.workflowEntries[key] = entry;
+                localStorage.setItem(k, JSON.stringify(sd));
+            });
+            showNotification(`${name} added to workflow`);
         }
 
         function sortByARR() {
@@ -1401,6 +1457,7 @@
                     `<td class="radar-actions">` +
                         `<button class="archive-btn" onclick="markAsDoneRiskmap(${riskmapData.indexOf(row)})" title="Archive this entry">Archive</button>` +
                         `<button class="todo-btn" onclick="toggleRadarDetail(${i})" title="Show details">Get To-Do</button>` +
+                        `<button class="workflow-add-btn" onclick="addToWorkflowRadar(${i})" title="Add to Workflow">+ Add</button>` +
                     `</td>` +
                 `</tr>`;
 
@@ -1590,7 +1647,7 @@
         });
     </script>
     <div id="radarPopup" class="popup-bg" style="display:none;">
-      <div class="popup-inner riskmap-popup-inner"></div>
+      <div class="popup-inner riskmap-popup-inner radar-panel"></div>
     </div>
 </body>
 </html>

--- a/utils.js
+++ b/utils.js
@@ -451,6 +451,7 @@ window.AppUtils = {
 
     SessionManager: {
         riskHistory: {},
+        workflowEntries: {},
         // Multi-Key Session-Management
         save: function(sessionData) {
             try {


### PR DESCRIPTION
## Summary
- integrate workflow sidebar with storage
- add buttons to add customers to workflow in tables
- make KPI charts responsive and fix z-index
- ensure radar popup width matches riskmap slider
- extend session data with workflow entries

## Testing
- `node --check app.js`
- `node --check utils.js`
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68421761a228832399ae8af2fc5d0f41