### PR TITLE
Add HTML escaping helper and sanitize table rendering

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 // app.js - KORRIGIERT: Synchrone ultra-robuste Zahlenextraktion
 
-const { DebugLogger, AutoSave, DataUtils, SessionManager, FileInputUtils, PrivacyUtils } = window.AppUtils;
+const { DebugLogger, AutoSave, DataUtils, SessionManager, FileInputUtils, PrivacyUtils, escapeHtml } = window.AppUtils;
 
 let excelData = [];
 let headers = [];
@@ -634,8 +634,8 @@ function renderSliderTable() {
         
         tableHTML += `
             <tr>
-                <td>${customerName}</td>
-                <td>${lcsm}</td>
+                <td>${escapeHtml(customerName)}</td>
+                <td>${escapeHtml(lcsm)}</td>
                 <td>€${arr.toLocaleString()}</td>
                 <td>${risk.toFixed(1)}</td>
                 <td>
@@ -932,9 +932,9 @@ function renderTable(data) {
                 tableHTML += `<td>€${arr.toLocaleString()}</td>`;
             } else if (col === 'Customer Name') {
                 const customerName = row['Customer Name'] || row['Kunde'] || row['Kundenname'] || row['Customer'] || row['Name'] || 'Unknown';
-                tableHTML += `<td>${customerName}</td>`;
+                tableHTML += `<td>${escapeHtml(customerName)}</td>`;
             } else {
-                tableHTML += `<td>${row[col] || ''}</td>`;
+                tableHTML += `<td>${escapeHtml(row[col] || '')}</td>`;
             }
         });
         tableHTML += '</tr>';

--- a/riskmap.html
+++ b/riskmap.html
@@ -1109,8 +1109,8 @@
                 
                 tableHTML += `
                     <tr>
-                        <td>${customerName}</td>
-                        <td>${lcsm}</td>
+                        <td>${AppUtils.escapeHtml(customerName)}</td>
+                        <td>${AppUtils.escapeHtml(lcsm)}</td>
                         <td>€${arr.toLocaleString()}</td>
                         <td>${risk.toFixed(1)}</td>
                         <td>
@@ -1351,14 +1351,14 @@
                             </div>
                         </div>`;
             html += '<table class="radar-details-table"><tbody>';
-            if (name !== null) html += `<tr><td>Customer Name</td><td>${name}</td></tr>`;
-            if (number !== null) html += `<tr><td>Customer Number</td><td>${number}</td></tr>`;
-            if (lcsm !== null) html += `<tr><td>LCSM</td><td>${lcsm}</td></tr>`;
+            if (name !== null) html += `<tr><td>Customer Name</td><td>${AppUtils.escapeHtml(name)}</td></tr>`;
+            if (number !== null) html += `<tr><td>Customer Number</td><td>${AppUtils.escapeHtml(number)}</td></tr>`;
+            if (lcsm !== null) html += `<tr><td>LCSM</td><td>${AppUtils.escapeHtml(lcsm)}</td></tr>`;
             if (arrVal !== null) html += `<tr><td>ARR</td><td>€${parseFloat(arrVal).toLocaleString()}</td></tr>`;
             if (!isNaN(totalRisk)) html += `<tr><td>Total Risk</td><td>${totalRisk.toFixed(1)}</td></tr>`;
-            if (lastContact) html += `<tr><td>Last Contact</td><td>${lastContact}</td></tr>`;
-            if (lastSuccess) html += `<tr><td>Last Success Check</td><td>${lastSuccess}</td></tr>`;
-            if (renewal) html += `<tr><td>Contract Renewal Date</td><td>${renewal}</td></tr>`;
+            if (lastContact) html += `<tr><td>Last Contact</td><td>${AppUtils.escapeHtml(lastContact)}</td></tr>`;
+            if (lastSuccess) html += `<tr><td>Last Success Check</td><td>${AppUtils.escapeHtml(lastSuccess)}</td></tr>`;
+            if (renewal) html += `<tr><td>Contract Renewal Date</td><td>${AppUtils.escapeHtml(renewal)}</td></tr>`;
             html += '</tbody></table>';
 
             const recs = [];

--- a/utils.js
+++ b/utils.js
@@ -48,6 +48,19 @@ function throttle(fn, limit = 300) {
     };
 }
 
+// Simple HTML escaping to prevent XSS when injecting dynamic values
+function escapeHtml(str) {
+    if (str === undefined || str === null) return '';
+    const map = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&#39;'
+    };
+    return String(str).replace(/[&<>"']/g, m => map[m]);
+}
+
 // =============================================================================
 // GLOBALER NAMESPACE (OHNE ES6 EXPORTS)
 // =============================================================================
@@ -60,6 +73,9 @@ window.AppUtils = {
         'Total Risk': ['Total Risk', 'total risk', 'TOTAL RISK', 'TotalRisk', 'totalrisk', 'TOTALRISK', 'Risk', 'risk', 'RISK', 'Risiko', 'risiko', 'RISIKO', 'Score', 'score', 'SCORE', 'Risk Score', 'risk score', 'RISK SCORE', 'RiskScore', 'riskscore', 'RISKSCORE'],
         'ARR': ['ARR', 'arr', 'Arr', 'Annual Recurring Revenue', 'annual recurring revenue', 'ANNUAL RECURRING REVENUE', 'Revenue', 'revenue', 'REVENUE', 'Umsatz', 'umsatz', 'UMSATZ', 'Vertragswert', 'vertragswert', 'VERTRAGSWERT', 'Value', 'value', 'VALUE', 'Wert', 'wert', 'WERT', 'Amount', 'amount', 'AMOUNT']
     },
+
+    // HTML escaping utility
+    escapeHtml: escapeHtml,
 
     // KORRIGIERT: IDENTISCHE Spaltenerkennung wie in app.js und riskmap.html
     findColumnName: function(headers, targetColumn) {


### PR DESCRIPTION
## Summary
- prevent HTML injection by adding `escapeHtml` helper
- sanitize dynamic table content in app.js
- sanitize risk map table in riskmap.html

## Testing
- `node - <<'NODE'
function escapeHtml(str){const map={'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'};return String(str).replace(/[&<>"']/g,m=>map[m])}
const user='<img src=x onerror=alert(1)>'
console.log(escapeHtml(user));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6842a234dc38832387f1e916ebfb13a1