### PR TITLE
Add adjustable logging level

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - Sort, filter and archive customer records
 - Risk heatmap view and simple dashboard
 - Data is stored only in browser storage – no server or tracking
+- Adjustable console log level via the footer dropdown
 
 ## Setup
 
@@ -21,6 +22,7 @@
 2. Use **Upload Data** to import your Excel file.
 3. Manage and review the table or open the risk map.
 4. Clear data or archive entries when finished.
+5. Adjust the log level using the footer selector if needed. Your choice is stored locally.
 
 ## External dependencies
 

--- a/app.html
+++ b/app.html
@@ -107,6 +107,12 @@
         <div class="footer-content-transparent">
             <a href="https://github.com/Olivetr33/No-More-Risk-" target="_blank" rel="noopener" class="github-link">GitHub</a>
             <button class="faq-footer-btn" id="faqBtn">❓ FAQ</button>
+            <select id="logLevelSelect" class="log-level-select">
+                <option value="debug">Debug</option>
+                <option value="info">Info</option>
+                <option value="warn">Warn</option>
+                <option value="error">Error</option>
+            </select>
         </div>
     </div>
 

--- a/app.js
+++ b/app.js
@@ -1577,6 +1577,14 @@ document.addEventListener('DOMContentLoaded', function() {
                 });
             }
 
+            const logSelect = document.getElementById('logLevelSelect');
+            if (logSelect && window.Logger) {
+                logSelect.value = Logger.getLevel();
+                logSelect.addEventListener('change', function(){
+                    Logger.saveLevel(this.value);
+                });
+            }
+
             updateTableVisibility();
             AutoSave.start(saveSession);
             

--- a/logger.js
+++ b/logger.js
@@ -7,7 +7,14 @@
     };
 
     const levels = { debug: 0, info: 1, warn: 2, error: 3, none: 4 };
-    let currentLevel = levels[(global.LOG_LEVEL || 'info').toLowerCase()] || levels.info;
+
+    function loadLevel() {
+        const stored = global.localStorage ? localStorage.getItem('logLevel') : null;
+        const levelName = (stored || global.LOG_LEVEL || 'info').toLowerCase();
+        return levels[levelName] !== undefined ? levels[levelName] : levels.info;
+    }
+
+    let currentLevel = loadLevel();
 
     function setLevel(level){
         if (typeof level === 'string') level = levels[level.toLowerCase()];
@@ -15,9 +22,27 @@
         currentLevel = level;
     }
 
+    function saveLevel(levelName){
+        if(typeof levelName === 'string'){
+            if(global.localStorage){
+                localStorage.setItem('logLevel', levelName.toLowerCase());
+            }
+            setLevel(levelName);
+        }
+    }
+
+    function getLevel(){
+        for(const key in levels){
+            if(levels[key] === currentLevel) return key;
+        }
+        return 'info';
+    }
+
     const logger = {
         levels,
         setLevel,
+        saveLevel,
+        getLevel,
         debug: (...args) => { if (currentLevel <= levels.debug) origConsole.log(...args); },
         info: (...args) => { if (currentLevel <= levels.info) origConsole.info(...args); },
         warn: (...args) => { if (currentLevel <= levels.warn) origConsole.warn(...args); },

--- a/riskmap.html
+++ b/riskmap.html
@@ -119,6 +119,12 @@
     <div class="footer-transparent" id="footerTransparent">
         <div class="footer-content-transparent">
             <a href="https://github.com/Olivetr33/No-More-Risk-" target="_blank" rel="noopener" class="github-link">GitHub</a>
+            <select id="logLevelSelect" class="log-level-select">
+                <option value="debug">Debug</option>
+                <option value="info">Info</option>
+                <option value="warn">Warn</option>
+                <option value="error">Error</option>
+            </select>
         </div>
     </div>
 
@@ -1596,6 +1602,14 @@
             }
             const closeRadarBtn = document.getElementById('closeRadarBtn');
             if (closeRadarBtn) closeRadarBtn.onclick = hideRadarPopup;
+
+            const logSelect = document.getElementById('logLevelSelect');
+            if (logSelect && window.Logger) {
+                logSelect.value = Logger.getLevel();
+                logSelect.addEventListener('change', function(){
+                    Logger.saveLevel(this.value);
+                });
+            }
 
             setTimeout(updateSortButtons, 500);
             setTimeout(updateSortButtons, 1000);

--- a/styles.css
+++ b/styles.css
@@ -705,6 +705,23 @@ body {
   transform: translateY(-2px);
 }
 
+.log-level-select {
+  background: none;
+  color: #ffffff;
+  border: 1px solid rgba(255,255,255,0.3);
+  border-radius: 25px;
+  padding: 10px 18px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.log-level-select:hover {
+  background: rgba(255,255,255,0.1);
+  border-color: rgba(255,255,255,0.6);
+}
+
 .chartjs-tooltip {
   background: var(--color-card) !important;
   border: 1px solid var(--color-accent) !important;


### PR DESCRIPTION
## Summary
- read log level from localStorage or LOG_LEVEL
- allow saving new level via a selector in the footer
- style dropdown consistent with existing footer buttons
- expose helper functions in `logger.js`
- document feature in README

## Testing
- `git status --short`
- `node -e "const Logger=require('./logger.js')"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6842a2389278832396dfe5ede46d58ad