### PR TITLE
Fix broken menu buttons due to archive slider bug

### DIFF
--- a/app.js
+++ b/app.js
@@ -634,7 +634,7 @@ function renderSliderTable() {
             riskBarWidth = '100%';
         }
         
-        const doneTag = row.tag === 'Done' ? `<span class="done-tag" onclick="removeFromArchiveSlider(${index})">Done</span>` : '';
+        const doneTag = customer.tag === 'Done' ? `<span class="done-tag" onclick="removeFromArchiveSlider(${index})">Done</span>` : '';
         const actionButton = `<button class="table-action-btn remove-btn" onclick="removeFromArchiveSlider(${index})">Remove</button>`;
         
         tableHTML += `


### PR DESCRIPTION
## Summary
- fix variable reference in `renderSliderTable` to avoid runtime errors

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6842a44cf3a08323a0d5af5f95587d73