### PR TITLE
Fix duplicate escapeHtml variable

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 // app.js - KORRIGIERT: Synchrone ultra-robuste Zahlenextraktion
 
-const { DebugLogger, AutoSave, DataUtils, SessionManager, FileInputUtils, PrivacyUtils, escapeHtml } = window.AppUtils;
+const { DebugLogger, AutoSave, DataUtils, SessionManager, FileInputUtils, PrivacyUtils } = window.AppUtils;
 
 let excelData = [];
 let headers = [];


### PR DESCRIPTION
## Summary
- remove `escapeHtml` from app.js destructuring to avoid shadowing global function

## Testing
- `node --check app.js`
- `node --check utils.js`
- `node --check logger.js`


------
https://chatgpt.com/codex/tasks/task_e_6842a7cffda48323bd1935db4dba1779