### PR TITLE
Fix debug panel and footer layout

### DIFF
--- a/app.html
+++ b/app.html
@@ -31,15 +31,15 @@
                 <ul>
                     <li><button class="sidebar-btn sidebar-btn-layout active" id="startBtn" data-target="goToStart">ShowData</button></li>
                     <li><button class="sidebar-btn sidebar-btn-layout" id="uploadDataBtn" data-target="triggerUpload">Upload Data</button></li>
-                    <li><button class="sidebar-btn sidebar-btn-layout" id="heatmapBtn" data-target="openHeatmap">📊 RiskMap</button></li>
-                    <li><button class="sidebar-btn sidebar-btn-layout" id="archiveBtn" data-target="showArchive">📋 Archive</button></li>
-                    <li><button class="sidebar-btn sidebar-btn-layout" id="kpiDashboardBtn" data-target="showKpiDashboard">📈 KPI Dashboard</button></li>
-                    <li><button class="sidebar-btn sidebar-btn-layout" id="workflowBtn" data-target="toggleWorkflow">🗂 Workflow</button></li>
+                    <li><button class="sidebar-btn sidebar-btn-layout" id="heatmapBtn" data-target="openHeatmap">RiskMap</button></li>
+                    <li><button class="sidebar-btn sidebar-btn-layout" id="archiveBtn" data-target="showArchive">Archive</button></li>
+                    <li><button class="sidebar-btn sidebar-btn-layout" id="kpiDashboardBtn" data-target="showKpiDashboard">KPI Dashboard</button></li>
+                    <li><button class="sidebar-btn sidebar-btn-layout" id="workflowBtn" data-target="toggleWorkflow">Workflow</button></li>
                 </ul>
             </nav>
             
             <div class="sidebar-footer">
-                <button class="sidebar-btn sidebar-btn-layout" id="saveSessionBtn" data-target="saveCurrentSession">💾 Save Session</button>
+                <button class="sidebar-btn sidebar-btn-layout" id="saveSessionBtn" data-target="saveCurrentSession">Save Session</button>
                 <button class="sidebar-btn sidebar-btn-layout logout-btn footer-btn" id="logoutBtn" data-target="performLogout">
                     Logout & Clear Session
                 </button>
@@ -47,7 +47,7 @@
         </div>
 
         <!-- Main Content -->
-        <div class="main-content" id="mainContent">
+        <div class="main-content with-footer" id="mainContent">
             <!-- Archive Upload Bar -->
             <div id="archiveUploadBar" class="archive-upload-bar" style="display: none;">
                 <div class="archive-info">
@@ -110,7 +110,7 @@
                 <a href="https://github.com/Olivetr33/No-More-Risk-" target="_blank" rel="noopener" class="github-link">GitHub</a>
                 <button class="faq-footer-btn footer-btn" id="faqBtn" data-target="showFaqModal">FAQ</button>
                 <div class="debug-dropdown">
-                    <button class="footer-link">Debug Log</button>
+                    <button class="footer-link" id="debugBtn">Debug Log</button>
                     <div class="dropdown-menu">
                         <label><input type="checkbox" value="debug" checked> Debug</label>
                         <label><input type="checkbox" value="info" checked> Info</label>
@@ -120,7 +120,6 @@
                 </div>
             </div>
         </div>
-        <div id="debugLog" class="debug-log"></div>
     </div>
 
     <div id="faqPopupBg" class="popup-bg" style="display:none;">
@@ -131,6 +130,10 @@
     </div>
 
     <div id="toastContainer" class="toast-container"></div>
+
+    <div id="debugLogPanel" class="debug-log-panel" style="display: none;">
+        <div id="debugLog" class="debug-log"></div>
+    </div>
 
     <!-- Dialog Background -->
     <div id="dialogBg" class="dialog-overlay" style="display: none;">

--- a/app.js
+++ b/app.js
@@ -1132,7 +1132,7 @@ function renderKpiDashboard() {
     sortDesc.className = 'sort-btn';
     sortDesc.textContent = '↓';
     const exportBtn = document.createElement('button');
-    exportBtn.textContent = '📤 Get Graphic';
+    exportBtn.textContent = 'Get Graphic';
     exportBtn.className = 'dashboard-export-btn sort-btn';
     const toggleHistory = document.createElement('label');
     toggleHistory.innerHTML = '<input type="checkbox" id="toggleRiskHistory"> Show Risk History';
@@ -1446,6 +1446,17 @@ window.completeWorkflow = function(key){
 
 document.addEventListener('DOMContentLoaded', function() {
     console.log('DOM Content Loaded - Setting up event listeners...');
+
+    document.querySelectorAll('.sidebar-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const view = btn.getAttribute('data-target');
+            if (view && typeof window[view] === 'function') {
+                window[view]();
+            } else {
+                console.warn('Missing or invalid view function:', view);
+            }
+        });
+    });
     
     let attempts = 0;
     const maxAttempts = 20;
@@ -1609,6 +1620,15 @@ document.addEventListener('DOMContentLoaded', function() {
                 const downloadBtn = debugDropdown.querySelector('button');
                 if(downloadBtn){
                     downloadBtn.onclick = AppUtils.DebugLogger.download.bind(AppUtils.DebugLogger);
+                }
+                const debugBtn = document.getElementById('debugBtn');
+                if (debugBtn) {
+                    debugBtn.addEventListener('click', () => {
+                        const panel = document.getElementById('debugLogPanel');
+                        if(panel){
+                            panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
+                        }
+                    });
                 }
                 Logger.display();
                 debugDropdown.addEventListener('change', function(e){

--- a/riskmap.html
+++ b/riskmap.html
@@ -27,15 +27,15 @@
                 <ul>
                     <li><button class="sidebar-btn sidebar-btn-layout" data-target="goToStart">ShowData</button></li>
                     <li><button class="sidebar-btn sidebar-btn-layout" data-target="triggerUpload">Upload Data</button></li>
-                    <li><button class="sidebar-btn sidebar-btn-layout active" >📊 RiskMap</button></li>
-                    <li><button class="sidebar-btn sidebar-btn-layout" data-target="showArchive">📋 Archive</button></li>
-                    <li><button class="sidebar-btn sidebar-btn-layout" id="kpiDashboardBtn" data-target="showKpiDashboard">📈 KPI Dashboard</button></li>
-                    <li><button class="sidebar-btn sidebar-btn-layout" id="workflowBtn" data-target="toggleWorkflow">🗂 Workflow</button></li>
+                    <li><button class="sidebar-btn sidebar-btn-layout active" >RiskMap</button></li>
+                    <li><button class="sidebar-btn sidebar-btn-layout" data-target="showArchive">Archive</button></li>
+                    <li><button class="sidebar-btn sidebar-btn-layout" id="kpiDashboardBtn" data-target="showKpiDashboard">KPI Dashboard</button></li>
+                    <li><button class="sidebar-btn sidebar-btn-layout" id="workflowBtn" data-target="toggleWorkflow">Workflow</button></li>
                 </ul>
             </nav>
             
             <div class="sidebar-footer">
-                <button class="sidebar-btn sidebar-btn-layout" data-target="saveCurrentSession">💾 Save Session</button>
+                <button class="sidebar-btn sidebar-btn-layout" data-target="saveCurrentSession">Save Session</button>
                 <button class="sidebar-btn sidebar-btn-layout logout-btn footer-btn" data-target="performLogout">
                     Logout & Clear Session
                 </button>
@@ -43,7 +43,7 @@
         </div>
 
         <!-- Main Content -->
-        <div class="main-content slider-open" id="mainContent">
+        <div class="main-content slider-open with-footer" id="mainContent">
             <input type="file" id="fileInput" accept=".xlsx,.xls,.csv" style="display: none;">
         </div>
 
@@ -122,7 +122,7 @@
             <div class="footer-button-group">
                 <a href="https://github.com/Olivetr33/No-More-Risk-" target="_blank" rel="noopener" class="github-link">GitHub</a>
                 <div class="debug-dropdown">
-                    <button class="footer-link">Debug Log</button>
+                    <button class="footer-link" id="debugBtn">Debug Log</button>
                     <div class="dropdown-menu">
                         <label><input type="checkbox" value="debug" checked> Debug</label>
                         <label><input type="checkbox" value="info" checked> Info</label>
@@ -132,7 +132,6 @@
                 </div>
             </div>
         </div>
-        <div id="debugLog" class="debug-log"></div>
     </div>
 
     <!-- Styles -->
@@ -1635,6 +1634,16 @@
                 });
             }
 
+            const debugBtn = document.getElementById('debugBtn');
+            if (debugBtn) {
+                debugBtn.addEventListener('click', function(){
+                    const panel = document.getElementById('debugLogPanel');
+                    if(panel){
+                        panel.style.display = panel.style.display === 'none' ? 'block' : 'none';
+                    }
+                });
+            }
+
             setTimeout(updateSortButtons, 500);
             setTimeout(updateSortButtons, 1000);
 
@@ -1650,5 +1659,9 @@
     </div>
 
     <div id="toastContainer" class="toast-container"></div>
+
+    <div id="debugLogPanel" class="debug-log-panel" style="display: none;">
+        <div id="debugLog" class="debug-log"></div>
+    </div>
 </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -853,3 +853,28 @@ body {
   border-radius: 0 12px 12px 0;
 }
 .workflow-table td,.workflow-table th{text-align:center;vertical-align:middle;}
+
+/* Footer padding helper */
+.with-footer {
+  padding-bottom: 80px;
+}
+
+/* Floating debug log panel */
+.debug-log-panel {
+  position: fixed;
+  bottom: 80px;
+  right: 20px;
+  width: 300px;
+  max-height: 200px;
+  overflow-y: auto;
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  padding: 10px;
+  border-radius: 8px;
+  z-index: 4000;
+}
+
+/* Remove sidebar highlight edge */
+.sidebar-btn-layout::after {
+  content: none !important;
+}


### PR DESCRIPTION
## Summary
- clean up icons in sidebar and KPI button text
- toggleable debug log panel
- adjust footer spacing and remove sidebar highlight
- ensure menu event listeners fire globally

## Testing
- `node -v`
- `node -e "require('fs').readFileSync('app.js','utf8');"`

------
https://chatgpt.com/codex/tasks/task_e_6842bf3c035883238650da5ab681e7bb