### PR TITLE
Improve file upload error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -719,11 +719,14 @@ function handleFile(e) {
     const file = e.target.files[0];
     if (!file) return;
 
+    console.debug('📁 File selected:', file.name, file.size);
+
     const reader = new FileReader();
     reader.onload = function(event) {
+        console.debug('✅ FileReader loaded, size:', event.target.result.byteLength);
         try {
             console.log('=== APP: File Upload Started ===');
-            
+
             const data = new Uint8Array(event.target.result);
             
             // KORRIGIERT: Einfache XLSX-Optionen - HIER WAR DER FEHLER!
@@ -813,9 +816,13 @@ function handleFile(e) {
             alert(`File uploaded successfully: ${extractedData.length} customers processed with corrected XLSX options`);
             
         } catch (error) {
-            console.error('APP: Processing error:', error);
+            console.error('❌ XLSX parsing failed:', error);
             alert(`File processing failed: ${error.message}`);
         }
+    };
+
+    reader.onerror = function(err) {
+        console.error('❌ FileReader error:', err);
     };
 
     reader.readAsArrayBuffer(file);

--- a/riskmap.html
+++ b/riskmap.html
@@ -1485,10 +1485,13 @@
             const file = e.target.files[0];
             if (!file) return;
 
+            console.debug('📁 File selected:', file.name, file.size);
+
             console.log('=== RiskMap File Upload Started ===');
 
             const reader = new FileReader();
             reader.onload = function(event) {
+                console.debug('✅ FileReader loaded, size:', event.target.result.byteLength);
                 try {
                     const data = new Uint8Array(event.target.result);
                     
@@ -1571,9 +1574,13 @@
                     showNotification(`Datei erfolgreich hochgeladen: ${extractedData.length} Kunden mit korrekten ARR-Werten verarbeitet!`);
                     
                 } catch (error) {
-                    console.error('=== RiskMap File Upload ERROR ===', error);
+                    console.error('❌ XLSX parsing failed:', error);
                     alert(`Dateiverarbeitung fehlgeschlagen: ${error.message}`);
                 }
+            };
+
+            reader.onerror = function(err) {
+                console.error('❌ FileReader error:', err);
             };
 
             reader.readAsArrayBuffer(file);


### PR DESCRIPTION
## Summary
- show file selection info
- add FileReader error handlers
- log when parsing fails

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6842c19ea0508323967c42c8adb19e63