### PR TITLE
Fix sheet selection for XLSX upload

### DIFF
--- a/app.js
+++ b/app.js
@@ -734,14 +734,34 @@ function handleFile(event) {
         const data = new Uint8Array(event.target.result);
         const workbook = XLSX.read(data, { type: 'array' });
 
-        const sheet = workbook.SheetNames[0];
-        const worksheet = workbook.Sheets[sheet];
-        const json = XLSX.utils.sheet_to_json(worksheet, {
-            header: 1,
-            raw: false,
-            defval: '',
-            blankrows: false
-        });
+        let chosenWorksheet = null;
+        let json = null;
+        for (const sheetName of workbook.SheetNames) {
+            const tempSheet = workbook.Sheets[sheetName];
+            const tempJson = XLSX.utils.sheet_to_json(tempSheet, {
+                header: 1,
+                raw: false,
+                defval: '',
+                blankrows: false
+            });
+            const validRows = tempJson.slice(1).filter(row =>
+                row.some(cell =>
+                    cell !== undefined &&
+                    cell !== null &&
+                    cell.toString().trim() !== ''
+                )
+            );
+            if (validRows.length > 0) {
+                chosenWorksheet = tempSheet;
+                json = [tempJson[0], ...validRows];
+                break;
+            }
+        }
+
+        if (!chosenWorksheet) {
+            alert('No sheet with valid data found in the uploaded file.');
+            return;
+        }
 
         headers = json[0].filter(header => header && header.toString().trim() !== '');
         console.log('APP: Original headers found:', headers);


### PR DESCRIPTION
## Summary
- search all workbook sheets for the first non-empty sheet when uploading files

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842e3fa09008323a67e6fbd5d357ac4