### PR TITLE
Enable global QuickNote and slider cleanup

### DIFF
--- a/riskmap.html
+++ b/riskmap.html
@@ -1161,6 +1161,16 @@
                         <td>
                             <button class="table-action-btn" onclick="markAsDoneRiskmap(${index})" title="Archive this entry">Archive</button>
                             <button class="table-action-btn" onclick="addToWorkflowRiskmap(${index})" title="Add to Workflow">➕ Add to Workflow</button>
+                            ${(() => {
+                                const key = AppUtils.DataUtils.generateCustomerKey(customer);
+                                const n = SessionManager.notes && SessionManager.notes[key];
+                                let preview = '';
+                                let hasNote = false;
+                                if(Array.isArray(n) && n.length){ preview = n[n.length-1].text.substring(0,50); hasNote = true; }
+                                else if(n && n.text){ preview = n.text.substring(0,50); hasNote = true; }
+                                const cls = hasNote ? ' quicknote-has-content' : '';
+                                return `<button class="table-action-btn note-btn${cls}" onclick="openNoteModal(${index})" title="${preview}">🗒</button>`;
+                            })()}
                         </td>
                     </tr>
                 `;
@@ -1234,6 +1244,65 @@
                     }, 300);
                 }
             }, 3000);
+        }
+
+        function openNoteModal(index){
+            const customer = riskmapData[index];
+            if(!customer) return;
+            const key = AppUtils.DataUtils.generateCustomerKey(customer);
+            let popup = document.getElementById('quicknotePopup');
+            if(!popup){
+                popup = document.createElement('div');
+                popup.id = 'quicknotePopup';
+                popup.className = 'quicknote-popup quicknote-panel';
+                document.body.appendChild(popup);
+            } else {
+                popup.className = 'quicknote-popup quicknote-panel';
+            }
+            const notesRaw = SessionManager.notes && SessionManager.notes[key];
+            const notes = Array.isArray(notesRaw) ? notesRaw : (notesRaw ? [notesRaw] : []);
+            const user = customer['LCSM'] || 'User';
+            const notesHtml = notes.map(n=>`<tr class="table-row"><td class="table-cell"><span class="note-timestamp">🕒 ${new Date(n.timestamp).toISOString().slice(0,16).replace('T',' ')}</span></td><td class="table-cell">${AppUtils.escapeHtml(user)}</td><td class="table-cell">${AppUtils.escapeHtml(n.text)}</td></tr>`).join('');
+            popup.innerHTML=`
+                <div class="slider-header filter-header">
+                    <h2 class="section-title">Quick Note</h2>
+                    <button class="close-slider-btn" id="closeNoteBtn">×</button>
+                </div>
+                <div class="slider-content">
+                    <table class="data-table">
+                        <thead><tr><th>Date</th><th>User</th><th>Note</th></tr></thead>
+                        <tbody>${notesHtml}
+                            <tr class="table-row">
+                                <td class="table-cell"></td>
+                                <td class="table-cell">${AppUtils.escapeHtml(user)}</td>
+                                <td class="table-cell"><textarea id="noteEditor" class="quicknote-content"></textarea></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                    <div class="filter-bar" style="margin-top:10px;">
+                        <button class="table-action-btn" id="saveNoteBtn">Save</button>
+                    </div>
+                </div>`;
+            popup.style.display='block';
+            document.getElementById('saveNoteBtn').onclick=function(){
+                const text=document.getElementById('noteEditor').value.trim();
+                if(text){
+                    if(!SessionManager.notes) SessionManager.notes={};
+                    if(!Array.isArray(SessionManager.notes[key])) SessionManager.notes[key]=[];
+                    const entry={text,timestamp:Date.now()};
+                    SessionManager.notes[key].push(entry);
+                    ['riskerSessionData','sessionData','appData'].forEach(k=>{
+                        let sd=JSON.parse(localStorage.getItem(k)||'{}');
+                        if(!sd.notes) sd.notes={};
+                        if(!Array.isArray(sd.notes[key])) sd.notes[key]=[];
+                        sd.notes[key].push(entry);
+                        localStorage.setItem(k,JSON.stringify(sd));
+                    });
+                }
+                popup.style.display='none';
+                updateRiskmapDisplay();
+            };
+            document.getElementById('closeNoteBtn').onclick=function(){popup.style.display='none';};
         }
 
         function addToWorkflowRiskmap(index){

--- a/styles.css
+++ b/styles.css
@@ -795,6 +795,18 @@ body {
 .filter-bar{display:flex;gap:15px;flex-wrap:wrap;}
 .note-timestamp{white-space:nowrap;}
 .quicknote-popup{position:fixed;top:50px;right:20px;width:420px;z-index:2000;}
+.quicknote-panel{
+  background: rgba(10,10,10,0.98);
+  backdrop-filter: blur(25px);
+  color:#fff;
+  border-left:4px solid transparent;
+  border-image:linear-gradient(to bottom,transparent 0%,transparent 15%,rgba(255,210,33,0.3) 20%,rgba(255,210,33,0.8) 40%,#ffd221 50%,rgba(255,210,33,0.8) 60%,rgba(255,210,33,0.3) 80%,transparent 85%,transparent 100%) 1;
+  box-shadow:-30px 0 60px rgba(0,0,0,0.8),0 0 40px rgba(255,210,33,0.6),inset 0 0 40px rgba(255,210,33,0.15);
+  border-radius:25px 0 0 25px;
+  padding:20px;
+  max-height:calc(100vh - 120px);
+  overflow-y:auto;
+}
 .quicknote-content{resize:none;height:180px;overflow-y:auto;}
 .debug-btn{margin-left:auto;}
 .footer-button-group {


### PR DESCRIPTION
## Summary
- manage slider conflicts with a new `closeAllSliders` helper
- style quicknote pop-up like sliders
- allow multiple notes per customer
- show note icons in archive, workflow and riskmap tables
- add note support in RiskMap implementation

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6842f427d0488323be7b56fdc30d880c