### PR TITLE
Add CSS for note wrapping and apply to QuickNote cells

### DIFF
--- a/app.js
+++ b/app.js
@@ -1371,7 +1371,7 @@ function openNoteModal(key){
     const allRows = [...filteredData, ...aggregatedData, ...erledigtRows];
     const row = allRows.find(r => DataUtils.generateCustomerKey(r) === key) || {};
     const user = row['LCSM'] || 'User';
-    const notesHtml = notes.map(n=>`<tr class="table-row"><td class="table-cell"><span class="note-timestamp">🕒 ${new Date(n.timestamp).toISOString().slice(0,16).replace('T',' ')}</span></td><td class="table-cell">${AppUtils.escapeHtml(user)}</td><td class="table-cell">${AppUtils.escapeHtml(n.text)}</td></tr>`).join('');
+    const notesHtml = notes.map(n=>`<tr class="table-row"><td class="table-cell"><span class="note-timestamp">🕒 ${new Date(n.timestamp).toISOString().slice(0,16).replace('T',' ')}</span></td><td class="table-cell">${AppUtils.escapeHtml(user)}</td><td class="table-cell note-text-cell">${AppUtils.escapeHtml(n.text)}</td></tr>`).join('');
     popup.innerHTML = `
         <div class="slider-header filter-header">
             <h2 class="section-title">Quick Note</h2>
@@ -1384,7 +1384,7 @@ function openNoteModal(key){
                     <tr class="table-row">
                         <td class="table-cell"></td>
                         <td class="table-cell">${AppUtils.escapeHtml(user)}</td>
-                        <td class="table-cell"><textarea id="noteEditor" class="quicknote-content quicknote-textarea"></textarea></td>
+                        <td class="table-cell note-text-cell"><textarea id="noteEditor" class="quicknote-content quicknote-textarea"></textarea></td>
                     </tr>
                 </tbody>
             </table>

--- a/riskmap.html
+++ b/riskmap.html
@@ -1267,7 +1267,7 @@
             const notesRaw = SessionManager.notes && SessionManager.notes[key];
             const notes = Array.isArray(notesRaw) ? notesRaw : (notesRaw ? [notesRaw] : []);
             const user = customer['LCSM'] || 'User';
-            const notesHtml = notes.map(n=>`<tr class="table-row"><td class="table-cell"><span class="note-timestamp">🕒 ${new Date(n.timestamp).toISOString().slice(0,16).replace('T',' ')}</span></td><td class="table-cell">${AppUtils.escapeHtml(user)}</td><td class="table-cell">${AppUtils.escapeHtml(n.text)}</td></tr>`).join('');
+            const notesHtml = notes.map(n=>`<tr class="table-row"><td class="table-cell"><span class="note-timestamp">🕒 ${new Date(n.timestamp).toISOString().slice(0,16).replace('T',' ')}</span></td><td class="table-cell">${AppUtils.escapeHtml(user)}</td><td class="table-cell note-text-cell">${AppUtils.escapeHtml(n.text)}</td></tr>`).join('');
             popup.innerHTML=`
                 <div class="slider-header filter-header">
                     <h2 class="section-title">Quick Note</h2>
@@ -1280,7 +1280,7 @@
                             <tr class="table-row">
                                 <td class="table-cell"></td>
                                 <td class="table-cell">${AppUtils.escapeHtml(user)}</td>
-                                <td class="table-cell"><textarea id="noteEditor" class="quicknote-content quicknote-textarea"></textarea></td>
+                                <td class="table-cell note-text-cell"><textarea id="noteEditor" class="quicknote-content quicknote-textarea"></textarea></td>
                             </tr>
                         </tbody>
                     </table>

--- a/styles.css
+++ b/styles.css
@@ -844,6 +844,10 @@ body {
   padding:4px 8px;
   vertical-align:top;
 }
+.note-text-cell{
+  word-break: break-word;
+  overflow-wrap: break-word;
+}
 .quicknote-save-btn{
   margin-top:12px;
   float:right;


### PR DESCRIPTION
## Summary
- add `.note-text-cell` style for wrapping long note text
- apply the new class to saved notes and textarea rows in QuickNote tables

## Testing
- `npm run setup`

------
https://chatgpt.com/codex/tasks/task_e_68430d59c77883238028b4974c9fbb25