### PR TITLE
Adjust QuickNote overlay and open modal behavior

### DIFF
--- a/app.js
+++ b/app.js
@@ -1356,15 +1356,14 @@ function showToast(message){
 }
 
 function openNoteModal(key){
-    closeAllSliders();
     let popup = document.getElementById('quicknotePopup');
     if(!popup){
         popup = document.createElement('div');
         popup.id = 'quicknotePopup';
-        popup.className = 'quicknote-popup quicknote-panel quicknote-slider-fixed';
+        popup.className = 'quicknote-popup quicknote-panel quicknote-slider-fixed quicknote-overlay';
         document.body.appendChild(popup);
     } else {
-        popup.className = 'quicknote-popup quicknote-panel quicknote-slider-fixed';
+        popup.className = 'quicknote-popup quicknote-panel quicknote-slider-fixed quicknote-overlay';
     }
     const notesRaw = SessionManager.notes && SessionManager.notes[key];
     const notes = Array.isArray(notesRaw) ? notesRaw : (notesRaw ? [notesRaw] : []);

--- a/riskmap.html
+++ b/riskmap.html
@@ -1254,15 +1254,14 @@
             const customer = riskmapData[index];
             if(!customer) return;
             const key = AppUtils.DataUtils.generateCustomerKey(customer);
-            closeAllSliders();
             let popup = document.getElementById('quicknotePopup');
             if(!popup){
                 popup = document.createElement('div');
                 popup.id = 'quicknotePopup';
-                popup.className = 'quicknote-popup quicknote-panel quicknote-slider-fixed';
+                popup.className = 'quicknote-popup quicknote-panel quicknote-slider-fixed quicknote-overlay';
                 document.body.appendChild(popup);
             } else {
-                popup.className = 'quicknote-popup quicknote-panel quicknote-slider-fixed';
+                popup.className = 'quicknote-popup quicknote-panel quicknote-slider-fixed quicknote-overlay';
             }
             const notesRaw = SessionManager.notes && SessionManager.notes[key];
             const notes = Array.isArray(notesRaw) ? notesRaw : (notesRaw ? [notesRaw] : []);

--- a/styles.css
+++ b/styles.css
@@ -939,3 +939,6 @@ body {
 .sidebar-btn-layout::after {
   content: none !important;
 }
+.quicknote-overlay {
+    z-index: 5000;
+}


### PR DESCRIPTION
## Summary
- keep the QuickNote panel open when opening the modal
- ensure QuickNote appears above other panels with a new overlay class

## Testing
- `npm run setup`

------
https://chatgpt.com/codex/tasks/task_e_68430e57a4688323a80a4ce1943f0ccf