### PR TITLE
Fix radar overflow and QuickNote slider

### DIFF
--- a/riskmap.html
+++ b/riskmap.html
@@ -1500,10 +1500,8 @@
             });
 
             html += '</tbody></table>';
-            html += '<button class="radar-close centered-btn" onclick="hideRadarPopup()">Close</button>';
-
-            const inner = document.getElementById('radarContent');
-            if (inner) inner.innerHTML = html;
+            const container = document.getElementById('radarTableContainer');
+            if (container) container.innerHTML = html;
 
             const sortHeader = document.getElementById('radarSort');
             if (sortHeader) {
@@ -1680,7 +1678,10 @@
         <h2>Top 10 Radar</h2>
         <button id="closeRadarBtn" class="close-slider-btn">×</button>
       </div>
-      <div class="slider-content" id="radarContent"></div>
+      <div class="slider-content" id="radarContent">
+        <div id="radarTableContainer"></div>
+        <button class="radar-close centered-btn" onclick="hideRadarPopup()">Close</button>
+      </div>
     </div>
 
     <div id="toastContainer" class="toast-container"></div>

--- a/styles.css
+++ b/styles.css
@@ -942,3 +942,20 @@ body {
 .quicknote-overlay {
     z-index: 5000;
 }
+
+#radarTableContainer {
+  max-height: calc(100vh - var(--footer-height));
+  overflow-y: auto;
+  padding-bottom: 100px;
+}
+
+#quickNoteSlider {
+  z-index: 999;
+  position: fixed;
+  right: 0;
+  top: 0;
+  height: 100%;
+  width: 400px;
+  background-color: #1a1a1a;
+  box-shadow: -2px 0 10px rgba(255,210,33,0.3);
+}


### PR DESCRIPTION
## Summary
- wrap radar table in scrollable container so footer no longer blocks last rows
- style QuickNote slider with fixed positioning and high z-index

## Testing
- `npm run setup`

------
https://chatgpt.com/codex/tasks/task_e_6843249d4d608323bb2492c1a77fccb4