### PR TITLE
Fix QuickNote overflow and faster RiskMap archive

### DIFF
--- a/app.js
+++ b/app.js
@@ -1397,7 +1397,7 @@ function openNoteModal(key){
             <h2 class="section-title">Quick Note</h2>
             <button class="close-slider-btn" id="closeNoteBtn">×</button>
         </div>
-        <div class="slider-content">
+        <div class="slider-content quicknote-container">
             <table class="data-table quick-note-table">
                 <thead><tr><th>Date</th><th>User</th><th>Note</th></tr></thead>
                 <tbody>${notesHtml}

--- a/riskmap.html
+++ b/riskmap.html
@@ -1112,7 +1112,7 @@
                             </div>
                         </td>
                         <td>
-                            <button class="table-action-btn" onclick="markAsDoneRiskmap(${index})" title="Archive this entry">Archive</button>
+                            <button class="table-action-btn" onclick="archiveCustomerRiskmap(${index}, this)" title="Archive this entry">Archive</button>
                             <button class="table-action-btn" onclick="addToWorkflowRiskmap(${index})" title="Add to Workflow">➕ Add to Workflow</button>
                             ${(() => {
                                 const key = AppUtils.DataUtils.generateCustomerKey(customer);
@@ -1165,8 +1165,6 @@
                 });
 
                 riskmapData.splice(customerIndex,1);
-                updateRiskmapDisplay();
-                showNotification('Customer archived successfully.');
             } catch(e){ console.error('Archive error',e); }
         }
 
@@ -1200,6 +1198,25 @@
             }, 3000);
         }
 
+        const archiveCustomerRiskmap = (() => {
+            const handler = function(idx, btn) {
+                if (btn) {
+                    btn.setAttribute('disabled', 'true');
+                    btn.classList.add('archiving');
+                }
+                requestAnimationFrame(() => {
+                    markAsDoneRiskmap(idx);
+                    if (btn) {
+                        const row = btn.closest('tr');
+                        if (row) row.remove();
+                    }
+                    updateStats();
+                    showNotification('Customer archived successfully.');
+                });
+            };
+            return debounce(handler, 200);
+        })();
+
         function openNoteModal(index){
             const customer = riskmapData[index];
             if(!customer) return;
@@ -1222,7 +1239,7 @@
                     <h2 class="section-title">Quick Note</h2>
                     <button class="close-slider-btn" id="closeNoteBtn">×</button>
                 </div>
-                <div class="slider-content">
+                <div class="slider-content quicknote-container">
                     <table class="data-table quick-note-table">
                         <thead><tr><th>Date</th><th>User</th><th>Note</th></tr></thead>
                         <tbody>${notesHtml}
@@ -1305,8 +1322,8 @@
             showToast('Added to Workflow.');
         }
 
-        function archiveFromRadar(idx){
-            markAsDoneRiskmap(idx);
+        function archiveFromRadar(idx, btn){
+            archiveCustomerRiskmap(idx, btn);
             hideRadarPopup();
         }
 
@@ -1475,7 +1492,7 @@
                     `<td>€${arrVal.toLocaleString()}</td>` +
                     `<td>${risk.toFixed(1)}</td>` +
                     `<td class="radar-actions">` +
-                        `<button class="table-action-btn" onclick="archiveFromRadar(${riskmapData.indexOf(row)})" title="Archive this entry">Archive</button>` +
+                        `<button class="table-action-btn" onclick="archiveFromRadar(${riskmapData.indexOf(row)}, this)" title="Archive this entry">Archive</button>` +
                         `<button class="table-action-btn" onclick="addToWorkflowRadar(${i})" title="Add to Workflow">➕ Add to Workflow</button>` +
                     `</td>` +
                 `</tr>`;

--- a/styles.css
+++ b/styles.css
@@ -829,6 +829,30 @@ body {
   padding:8px;
   resize:vertical;
 }
+
+#quickNoteSlider textarea{
+  width:100%;
+  max-width:100%;
+  box-sizing:border-box;
+  resize:vertical;
+  overflow-wrap:break-word;
+  word-break:break-word;
+  background-color:#2a2a2a;
+  color:#fff;
+  border-radius:6px;
+  padding:8px;
+  border:1px solid rgba(255,255,255,0.1);
+}
+
+.quicknote-container{
+  overflow:hidden;
+  padding:16px;
+}
+
+.archiving{
+  opacity:0.6;
+  pointer-events:none;
+}
 .quick-note-table{
   width:100%;
   border-spacing:0 6px;


### PR DESCRIPTION
## Summary
- prevent QuickNote textarea overflow with new styles and container class
- debounce RiskMap archive button to avoid laggy rerenders
- remove archived rows without rebuilding the whole table

## Testing
- `npm run setup`

------
https://chatgpt.com/codex/tasks/task_e_68432a50bca883238fac422106e97837