### PR TITLE
Consolidate ShowData view and add session file workflow

### DIFF
--- a/app.js
+++ b/app.js
@@ -1285,6 +1285,19 @@ function renderKpiDashboard() {
             }
         });
         window.addEventListener('resize', () => chart.resize());
+        chart.canvas.onclick = function(evt){
+            const points = chart.getElementsAtEventForMode(evt, 'nearest', {intersect:true}, true);
+            if(points.length){
+                const idx = points[0].index;
+                const customer = dashboardData[idx];
+                const cid = customer['Customer Number'] || customer['Customer ID'] || customer['Kundennummer'] || '';
+                if(cid){
+                    navigator.clipboard.writeText(cid).then(() => {
+                        showToast(`\uD83D\uDCCB Copied ID: ${cid}`);
+                    });
+                }
+            }
+        };
     }
 
     metricSelect.onchange = () => { currentSort = 'desc'; if(typeof Chart!=='undefined') updateChart(); };
@@ -1458,7 +1471,15 @@ window.QuickNote = QuickNote;
 
 window.saveCurrentSession = function(){
     saveSession();
-    showToast('Session saved successfully.');
+    const data = SessionManager.restore() || {};
+    const blob = new Blob([JSON.stringify(data)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `risker-session-${Date.now()}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+    showToast('Session file downloaded.');
 };
 
 function addWorkflowEntry(row){

--- a/riskmap.html
+++ b/riskmap.html
@@ -25,17 +25,24 @@
         <div class="sidebar">
             <nav class="sidebar-nav">
                 <ul>
-                    <li><button class="sidebar-btn sidebar-btn-layout" data-target="goToStart">ShowData</button></li>
-                    <li><button class="sidebar-btn sidebar-btn-layout" data-target="triggerUpload">Upload Data</button></li>
-                    <li><button class="sidebar-btn sidebar-btn-layout active" >RiskMap</button></li>
-                    <li><button class="sidebar-btn sidebar-btn-layout" data-target="showArchive">Archive</button></li>
+                    <li class="upload-dropdown">
+                        <button class="sidebar-btn sidebar-btn-layout" id="uploadDataBtn">Upload Data ▾</button>
+                        <div class="upload-options" id="uploadOptions">
+                            <button data-action="uploadXlsx">Upload XLSX</button>
+                            <button data-action="restoreSession">Restore Session File</button>
+                        </div>
+                    </li>
+                    <li><button class="sidebar-btn sidebar-btn-layout active">RiskMap</button></li>
                     <li><button class="sidebar-btn sidebar-btn-layout" id="kpiDashboardBtn" data-target="showKpiDashboard">KPI Dashboard</button></li>
                     <li><button class="sidebar-btn sidebar-btn-layout" id="workflowBtn" data-target="toggleWorkflow">Workflow</button></li>
                 </ul>
             </nav>
-            
+
             <div class="sidebar-footer">
-                <button class="sidebar-btn sidebar-btn-layout" data-target="saveCurrentSession">Save Session</button>
+                <div class="sidebar-group">
+                    <button class="sidebar-btn sidebar-btn-layout" data-target="saveCurrentSession">Save Session</button>
+                    <button class="sidebar-btn sidebar-btn-layout" data-target="showArchive" id="openArchiveBtn">Archive</button>
+                </div>
                 <button class="sidebar-btn sidebar-btn-layout logout-btn footer-btn" data-target="performLogout">
                     Logout & Clear Session
                 </button>
@@ -51,7 +58,7 @@
         <div id="sliderPanel" class="slider-panel active">
             <div class="slider-header">
                 <h2 id="sliderTitle">RISKMAP</h2>
-                <button onclick="window.location.href='app.html'" class="close-slider-btn">×</button>
+                <button onclick="closeAllSliders()" class="close-slider-btn">×</button>
             </div>
             
             <div class="slider-content" id="sliderContent">
@@ -712,10 +719,32 @@
         const { DataUtils, SessionManager } = window.AppUtils;
         function saveCurrentSession(){
             try{
-                const data = localStorage.getItem('riskerSessionData');
-                if(data) localStorage.setItem('riskerSessionData', data);
-                showToast('Session saved successfully.');
+                const session = SessionManager.restore() || {};
+                const blob = new Blob([JSON.stringify(session)], { type: 'application/json' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = `risker-session-${Date.now()}.json`;
+                a.click();
+                URL.revokeObjectURL(url);
+                showToast('Session file downloaded.');
             }catch(e){console.error(e);}
+        }
+
+        function restoreSessionFile(file){
+            const reader = new FileReader();
+            reader.onload = function(ev){
+                try{
+                    const data = JSON.parse(ev.target.result);
+                    SessionManager.save(data);
+                    riskmapData = (data.filteredData || []).filter(c => !c.erledigt && !c.done && !c.archived);
+                    updateRiskmapDisplay();
+                    showToast('Session restored.');
+                }catch(err){
+                    alert('Invalid session file');
+                }
+            };
+            reader.readAsText(file);
         }
         function showToast(msg){
             const cont = document.getElementById('toastContainer');
@@ -902,13 +931,14 @@
 
         // Globale Funktionen für Sidebar-Buttons
         window.goToStart = function() {
-            console.log('ShowData function called from RiskMap');
-            window.location.href = 'app.html';
+            console.log('ShowData function removed.');
         };
 
         window.showArchive = function() {
-            console.log('Archive function called from RiskMap');
-            window.location.href = 'app.html?openArchive=true';
+            console.log('Displaying archive in RiskMap');
+            const session = SessionManager.restore() || {};
+            riskmapData = (session.archivedRows || []).slice();
+            updateRiskmapDisplay();
         };
 
         window.openHeatmap = function() {
@@ -1564,13 +1594,21 @@
                     })));
                 }
 
+                const existing = SessionManager.restore() || {};
+                const existingKeys = new Set([
+                    ...(existing.filteredData || []),
+                    ...(existing.erledigtRows || []),
+                    ...(existing.archivedRows || [])
+                ].map(r => DataUtils.generateCustomerKey(r)));
+                const uniqueData = extractedData.filter(row => !existingKeys.has(DataUtils.generateCustomerKey(row)));
+                const merged = (existing.filteredData || []).concat(uniqueData);
                 const sessionData = {
-                    excelData: rawData,
-                    filteredData: extractedData,
-                    aggregatedData: extractedData,
-                    originalAggregatedData: [...extractedData],
-                    selectedLCSM: null,
-                    erledigtRows: [],
+                    excelData: (existing.excelData || []).concat(rawData),
+                    filteredData: merged,
+                    aggregatedData: merged,
+                    originalAggregatedData: [...merged],
+                    selectedLCSM: existing.selectedLCSM || null,
+                    erledigtRows: existing.erledigtRows || [],
                     headers: headers,
                     currentSort: { column: '', direction: 'desc' },
                     archiveMode: false,
@@ -1583,7 +1621,7 @@
                     console.log(`RiskMap: Session data saved to key: ${key}`);
                 }
 
-                riskmapData = extractedData.filter(customer => !customer.erledigt);
+                riskmapData = merged.filter(customer => !customer.erledigt && !customer.archived && !customer.done);
                 console.log('RiskMap: Updated local data:', riskmapData.length, 'customers');
 
                 updateRiskmapDisplay();
@@ -1613,6 +1651,30 @@
                     }
                 });
             });
+
+            const uploadBtn = document.getElementById('uploadDataBtn');
+            const uploadOptions = document.getElementById('uploadOptions');
+            if (uploadBtn && uploadOptions) {
+                uploadBtn.addEventListener('click', function(){
+                    uploadOptions.style.display = uploadOptions.style.display === 'flex' ? 'none' : 'flex';
+                });
+                uploadOptions.addEventListener('click', function(e){
+                    const action = e.target.dataset.action;
+                    if (action === 'uploadXlsx') {
+                        window.triggerUpload();
+                    } else if (action === 'restoreSession') {
+                        const input = document.createElement('input');
+                        input.type = 'file';
+                        input.accept = '.riskersession.json';
+                        input.addEventListener('change', function(ev){
+                            const file = ev.target.files[0];
+                            if (file) restoreSessionFile(file);
+                        }, { once: true });
+                        input.click();
+                    }
+                    uploadOptions.style.display = 'none';
+                });
+            }
             
             loadRiskmapData();
             bindQuickNoteButtons();

--- a/styles.css
+++ b/styles.css
@@ -953,3 +953,43 @@ body {
   background-color: #1a1a1a;
   box-shadow: -2px 0 10px rgba(255,210,33,0.3);
 }
+# Upload Data button custom style
+#uploadDataBtn {
+    border-radius: 0 20px 20px 0;
+    background: #ffd221;
+    color: #000;
+    padding: 12px 16px;
+    font-weight: bold;
+}
+
+.sidebar-group {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-bottom: 20px;
+}
+
+.upload-dropdown { position: relative; }
+.upload-options {
+    position: absolute;
+    left: 100%;
+    top: 0;
+    background: rgba(30,30,30,0.95);
+    border-radius: 8px;
+    padding: 10px;
+    display: none;
+    flex-direction: column;
+    gap: 8px;
+}
+.upload-options button {
+    background: rgba(255,255,255,0.05);
+    color: #fff;
+    border: none;
+    border-radius: 8px;
+    padding: 8px 12px;
+    cursor: pointer;
+}
+.upload-options button:hover {
+    background: rgba(255,255,255,0.1);
+}
+


### PR DESCRIPTION
## Summary
- integrate session save/export into RiskMap
- add upload menu with XLSX and session restore
- move Archive button next to Save Session
- make Upload Data button stand out
- copy customer ID on KPI chart bar click

## Testing
- `npm run setup`

------
https://chatgpt.com/codex/tasks/task_e_68433d91f6e88323a6e4a043d129c2c6