### PR TITLE
Refine startup flow and KPI interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@
 ## Project structure
 
 - `index.html` – start screen
-- `app.html` – main dashboard
-- `riskmap.html` – risk map view
+- `riskmap.html` – main dashboard
 - `app.js` / `utils.js` – application logic
 - `styles.css` – styling
 - `background.mp4` – optional background video

--- a/app.js
+++ b/app.js
@@ -1284,7 +1284,38 @@ function renderKpiDashboard() {
                 scales:{x:{ticks:{color:'#f1f1f1'}}, y:{ticks:{color:'#f1f1f1'}}}
             }
         });
-        window.addEventListener('resize', () => chart.resize());
+        const overlayFn = () => {
+            const overlay = chartWrap.querySelector('.kpi-bar-overlay');
+            if (overlay) overlay.remove();
+            const ov = document.createElement('div');
+            ov.className = 'kpi-bar-overlay';
+            chartWrap.appendChild(ov);
+            const meta = chart.getDatasetMeta(0);
+            meta.data.forEach((bar, i) => {
+                const props = bar.getProps(['x','y','base','width','height'], true);
+                const left = Math.min(props.base, props.x);
+                const width = Math.abs(props.x - props.base);
+                const top = props.y - props.height / 2;
+                const div = document.createElement('div');
+                div.className = 'kpi-bar';
+                div.dataset.customerId = dashboardData[i]['Customer Number'] || dashboardData[i]['Customer ID'] || dashboardData[i]['Kundennummer'] || '';
+                div.style.left = left + 'px';
+                div.style.top = top + 'px';
+                div.style.width = width + 'px';
+                div.style.height = props.height + 'px';
+                div.addEventListener('click', () => {
+                    const cid = div.dataset.customerId;
+                    if (cid) {
+                        navigator.clipboard.writeText(cid).then(() => {
+                            showToast(`\uD83D\uDCCB Copied ID: ${cid}`);
+                        });
+                    }
+                });
+                ov.appendChild(div);
+            });
+        };
+        window.addEventListener('resize', () => { chart.resize(); overlayFn(); });
+        setTimeout(overlayFn, 0);
         chart.canvas.onclick = function(evt){
             const points = chart.getElementsAtEventForMode(evt, 'nearest', {intersect:true}, true);
             if(points.length){

--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
             Your browser does not support the video tag.
         </video>
         <div class="startup-overlay">
-            <button class="startup-btn" id="startBtn" onclick="window.location='app.html'">
+            <button class="startup-btn" id="startBtn" onclick="window.location='riskmap.html'">
                 NO MORE RISK!
             </button>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -993,3 +993,16 @@ body {
     background: rgba(255,255,255,0.1);
 }
 
+.kpi-bar-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+}
+
+.kpi-bar {
+    position: absolute;
+    pointer-events: auto;
+    cursor: pointer;
+}
+


### PR DESCRIPTION
## Summary
- make start button open riskmap directly
- document new main dashboard location
- add overlay elements for copying IDs from KPI bars
- style overlay elements

## Testing
- `npm run setup`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68434082c9dc8323b2de93bcbb1d372c