### PR TITLE
Fix sidebar and risk map issues

### DIFF
--- a/app.js
+++ b/app.js
@@ -339,6 +339,7 @@ window.openHeatmap = function() {
     if (aggregatedData && aggregatedData.length > 0) {
         console.log('Opening RiskMap from app.html');
         window.location.href = "riskmap.html";
+        highlightSidebarButton('heatmapBtn');
     } else {
         alert('Please upload and process data first before viewing the RiskMap.');
     }
@@ -853,6 +854,8 @@ function handleFile(event) {
 
             console.log('=== APP: File Upload SUCCESS ===');
             alert(`File uploaded successfully: ${extractedData.length} customers processed`);
+            renderRiskMap();
+            highlightSidebarButton('heatmapBtn');
         }
         uploadInProgress = false;
     } catch (error) {
@@ -1603,6 +1606,7 @@ function renderWorkflowSidebar(){
     });
     table.innerHTML = html;
     bindQuickNoteButtons();
+    setupSidebarNavigation();
 }
 
 function markWorkflowItemDone(entryId){
@@ -1650,16 +1654,7 @@ document.addEventListener('DOMContentLoaded', function() {
         console.warn('❌ fileInput not found in DOM');
     }
 
-    document.querySelectorAll('.sidebar-btn').forEach(btn => {
-        btn.addEventListener('click', () => {
-            const view = btn.getAttribute('data-target');
-            if (view && typeof window[view] === 'function') {
-                window[view]();
-            } else {
-                console.warn('Missing or invalid view function:', view);
-            }
-        });
-    });
+    setupSidebarNavigation();
     
     let attempts = 0;
     const maxAttempts = 20;
@@ -1800,16 +1795,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 faqBtn.onclick = showFaqModal;
             }
 
-            document.querySelectorAll('.sidebar-btn[data-target]').forEach(btn => {
-                btn.addEventListener('click', function(){
-                    const target = this.dataset.target;
-                    if (typeof window[target] === 'function') {
-                        window[target]();
-                    } else {
-                        console.warn('Missing target function for:', target);
-                    }
-                });
-            });
+            setupSidebarNavigation();
 
             const faqBg = document.getElementById('faqPopupBg');
             if (faqBg) {

--- a/riskmap.html
+++ b/riskmap.html
@@ -732,19 +732,15 @@
         }
 
         function restoreSessionFile(file){
-            const reader = new FileReader();
-            reader.onload = function(ev){
-                try{
-                    const data = JSON.parse(ev.target.result);
-                    SessionManager.save(data);
-                    riskmapData = (data.filteredData || []).filter(c => !c.erledigt && !c.done && !c.archived);
-                    updateRiskmapDisplay();
-                    showToast('Session restored.');
-                }catch(err){
-                    alert('Invalid session file');
-                }
-            };
-            reader.readAsText(file);
+            AppUtils.handleSessionUpload(file, function(data){
+                riskmapData = (data.filteredData || []).filter(c => !c.erledigt && !c.done && !c.archived);
+                updateRiskmapDisplay();
+                renderRiskMap();
+                highlightSidebarButton('heatmapBtn');
+                showToast('✅ Session imported.');
+            }, function(){
+                showToast('❌ Failed to import session.');
+            });
         }
         function showToast(msg){
             const cont = document.getElementById('toastContainer');
@@ -1628,6 +1624,7 @@
 
                 console.log('=== RiskMap File Upload SUCCESS ===');
                 showNotification(`Datei erfolgreich hochgeladen: ${extractedData.length} Kunden mit korrekten ARR-Werten verarbeitet!`);
+                highlightSidebarButton('heatmapBtn');
                 uploadInProgress = false;
 
             }, function(error){
@@ -1641,16 +1638,7 @@
         document.addEventListener('DOMContentLoaded', function() {
             console.log('=== RiskMap DOM Ready ===');
 
-            document.querySelectorAll('.sidebar-btn[data-target]').forEach(function(btn){
-                btn.addEventListener('click', function(){
-                    var target = this.dataset.target;
-                    if(typeof window[target] === 'function'){
-                        window[target]();
-                    }else{
-                        console.warn('Missing target function for:', target);
-                    }
-                });
-            });
+            setupSidebarNavigation();
 
             const uploadBtn = document.getElementById('uploadDataBtn');
             const uploadOptions = document.getElementById('uploadOptions');


### PR DESCRIPTION
## Summary
- rebind sidebar navigation after render
- add utility functions to handle session uploads and sidebar highlighting
- ensure RiskMap view loads after data imports
- improve session restoration workflow

## Testing
- `npm run setup`

------
https://chatgpt.com/codex/tasks/task_e_6843449c67888323b618d4b188ac503a