### PR TITLE
Fix upload rendering and sidebar events

### DIFF
--- a/app.js
+++ b/app.js
@@ -854,8 +854,10 @@ function handleFile(event) {
 
             console.log('=== APP: File Upload SUCCESS ===');
             alert(`File uploaded successfully: ${extractedData.length} customers processed`);
+            if (SessionManager.parseImportedData) SessionManager.parseImportedData();
             renderRiskMap();
             highlightSidebarButton('heatmapBtn');
+            setupSidebarButtons();
         }
         uploadInProgress = false;
     } catch (error) {
@@ -1606,7 +1608,7 @@ function renderWorkflowSidebar(){
     });
     table.innerHTML = html;
     bindQuickNoteButtons();
-    setupSidebarNavigation();
+    setupSidebarButtons();
 }
 
 function markWorkflowItemDone(entryId){
@@ -1654,7 +1656,7 @@ document.addEventListener('DOMContentLoaded', function() {
         console.warn('❌ fileInput not found in DOM');
     }
 
-    setupSidebarNavigation();
+    setupSidebarButtons();
     
     let attempts = 0;
     const maxAttempts = 20;
@@ -1795,7 +1797,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 faqBtn.onclick = showFaqModal;
             }
 
-            setupSidebarNavigation();
+            setupSidebarButtons();
 
             const faqBg = document.getElementById('faqPopupBg');
             if (faqBg) {

--- a/riskmap.html
+++ b/riskmap.html
@@ -735,8 +735,10 @@
             AppUtils.handleSessionUpload(file, function(data){
                 riskmapData = (data.filteredData || []).filter(c => !c.erledigt && !c.done && !c.archived);
                 updateRiskmapDisplay();
+                if(SessionManager.parseImportedData) SessionManager.parseImportedData();
                 renderRiskMap();
                 highlightSidebarButton('heatmapBtn');
+                setupSidebarButtons();
                 showToast('✅ Session imported.');
             }, function(){
                 showToast('❌ Failed to import session.');
@@ -1624,7 +1626,10 @@
 
                 console.log('=== RiskMap File Upload SUCCESS ===');
                 showNotification(`Datei erfolgreich hochgeladen: ${extractedData.length} Kunden mit korrekten ARR-Werten verarbeitet!`);
+                if(SessionManager.parseImportedData) SessionManager.parseImportedData();
+                renderRiskMap();
                 highlightSidebarButton('heatmapBtn');
+                setupSidebarButtons();
                 uploadInProgress = false;
 
             }, function(error){
@@ -1638,7 +1643,7 @@
         document.addEventListener('DOMContentLoaded', function() {
             console.log('=== RiskMap DOM Ready ===');
 
-            setupSidebarNavigation();
+            setupSidebarButtons();
 
             const uploadBtn = document.getElementById('uploadDataBtn');
             const uploadOptions = document.getElementById('uploadOptions');

--- a/utils.js
+++ b/utils.js
@@ -558,6 +558,19 @@ window.AppUtils = {
                 data.filteredData || [],
                 data.aggregatedData || []
             );
+        },
+
+        parseImportedData: function() {
+            try {
+                const data = this.restore() || {};
+                this.riskHistory = data.riskHistory || {};
+                this.workflowEntries = data.workflowEntries || {};
+                this.notes = data.notes || {};
+                return data;
+            } catch (e) {
+                console.warn('SessionManager.parseImportedData failed', e);
+                return {};
+            }
         }
     },
 
@@ -782,6 +795,13 @@ function setupSidebarNavigation() {
     });
 }
 
+function setupSidebarButtons() {
+    document.querySelectorAll('.sidebar-btn').forEach(btn => {
+        btn.removeEventListener('click', handleSidebarNavigationClick);
+        btn.addEventListener('click', handleSidebarNavigationClick);
+    });
+}
+
 function highlightSidebarButton(buttonId) {
     document.querySelectorAll('.sidebar-btn').forEach(btn => btn.classList.remove('active'));
     const btn = document.getElementById(buttonId);
@@ -799,12 +819,13 @@ function renderRiskMap() {
 window.handleQuickNoteOpen = handleQuickNoteOpen;
 window.bindQuickNoteButtons = bindQuickNoteButtons;
 window.setupSidebarNavigation = setupSidebarNavigation;
+window.setupSidebarButtons = setupSidebarButtons;
 window.highlightSidebarButton = highlightSidebarButton;
 window.renderRiskMap = renderRiskMap;
 
 if (typeof document !== 'undefined') {
     document.addEventListener('DOMContentLoaded', () => {
         bindQuickNoteButtons();
-        setupSidebarNavigation();
+        setupSidebarButtons();
     });
 }


### PR DESCRIPTION
## Summary
- ensure uploaded data instantly triggers risk map update
- add helper to rebind sidebar button events after DOM changes
- refresh sidebar event listeners after uploads, session restore, and page load

## Testing
- `npm run setup`

------
https://chatgpt.com/codex/tasks/task_e_6843489fc8d8832399f696e135b82329