### PR TITLE
Fix sidebar navigation from RiskMap page

### DIFF
--- a/app.js
+++ b/app.js
@@ -1137,6 +1137,18 @@ function checkUrlParameters() {
             window.showArchive();
         }, 500);
     }
+    if (urlParams.get('openKpi') === 'true') {
+        console.log('URL parameter detected - opening KPI dashboard automatically');
+        setTimeout(() => {
+            showKpiDashboard();
+        }, 500);
+    }
+    if (urlParams.get('openWorkflow') === 'true') {
+        console.log('URL parameter detected - opening workflow automatically');
+        setTimeout(() => {
+            toggleWorkflow();
+        }, 500);
+    }
 }
 
 function showKpiDashboard() {

--- a/riskmap.html
+++ b/riskmap.html
@@ -933,10 +933,15 @@
         };
 
         window.showArchive = function() {
-            console.log('Displaying archive in RiskMap');
-            const session = SessionManager.restore() || {};
-            riskmapData = (session.archivedRows || []).slice();
-            updateRiskmapDisplay();
+            window.location.href = 'app.html?openArchive=true';
+        };
+
+        window.showKpiDashboard = function() {
+            window.location.href = 'app.html?openKpi=true';
+        };
+
+        window.toggleWorkflow = function() {
+            window.location.href = 'app.html?openWorkflow=true';
         };
 
         window.openHeatmap = function() {


### PR DESCRIPTION
## Summary
- ensure sidebar buttons from `riskmap.html` open correct views in `app.html`
- allow `app.html` to respond to `openKpi` and `openWorkflow` URL params

## Testing
- `npm run setup`

------
https://chatgpt.com/codex/tasks/task_e_684478361d448323ac8b8d61a790508b