### PR TITLE
Fix RiskMap view and cleanup main content

### DIFF
--- a/app.js
+++ b/app.js
@@ -327,18 +327,11 @@ window.openHeatmap = function() {
 
     const kpiContainer = document.getElementById('kpiDashboardContainer');
     if (kpiContainer) kpiContainer.classList.remove('active');
-    
-    const currentUrl = window.location.href;
-    
-    if (currentUrl.includes('riskmap.html')) {
-        console.log('Currently in RiskMap - closing and returning to ShowData');
-        window.location.href = 'app.html';
-        return;
-    }
-    
+
     if (aggregatedData && aggregatedData.length > 0) {
-        console.log('Opening RiskMap from app.html');
-        window.location.href = "riskmap.html";
+        closeAllSliders();
+        if (typeof clearMainContent === 'function') clearMainContent();
+        renderRiskMap();
         highlightSidebarButton('heatmapBtn');
     } else {
         alert('Please upload and process data first before viewing the RiskMap.');

--- a/utils.js
+++ b/utils.js
@@ -791,25 +791,33 @@ function setupSidebarNavigation() {
     });
 }
 
+function clearMainContent() {
+    const contentArea = document.getElementById('mainContent');
+    if (contentArea) {
+        contentArea.innerHTML = '';
+    }
+}
+
 function renderView(view) {
     if (typeof closeAllSliders === 'function') closeAllSliders();
+    if (typeof clearMainContent === 'function') clearMainContent();
     switch (view) {
-        case 'riskMap':
-            if (typeof renderRiskMap === 'function') renderRiskMap();
-            highlightSidebarButton('heatmapBtn');
-            break;
-        case 'workflow':
-            if (typeof toggleWorkflow === 'function') toggleWorkflow();
-            highlightSidebarButton('workflowBtn');
-            break;
-        case 'topRadar':
-            if (typeof showRadarPopup === 'function') showRadarPopup();
-            highlightSidebarButton('radarSidebarBtn');
-            break;
-        case 'kpiDashboard':
-            if (typeof showKpiDashboard === 'function') showKpiDashboard();
-            highlightSidebarButton('kpiDashboardBtn');
-            break;
+    case 'riskMap':
+        if (typeof renderRiskMap === 'function') renderRiskMap();
+        highlightSidebarButton('heatmapBtn');
+        break;
+    case 'workflow':
+        if (typeof toggleWorkflow === 'function') toggleWorkflow();
+        highlightSidebarButton('workflowBtn');
+        break;
+    case 'topRadar':
+        if (typeof showRadarPopup === 'function') showRadarPopup();
+        highlightSidebarButton('radarSidebarBtn');
+        break;
+    case 'kpiDashboard':
+        if (typeof showKpiDashboard === 'function') showKpiDashboard();
+        highlightSidebarButton('kpiDashboardBtn');
+        break;
     }
 }
 
@@ -851,6 +859,7 @@ window.setupSidebarButtons = setupSidebarButtons;
 window.highlightSidebarButton = highlightSidebarButton;
 window.renderRiskMap = renderRiskMap;
 window.renderView = renderView;
+window.clearMainContent = clearMainContent;
 
 if (typeof document !== 'undefined') {
     document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- add `clearMainContent` helper and use it when rendering views
- update Risk Map button handler to render the map without leaving the page
- export new helper in utils

## Testing
- `npm run setup`

------
https://chatgpt.com/codex/tasks/task_e_684485e7905c83239cab97d3f13be87b