### PR TITLE
Fix risk map rendering and residual content cleanup

### DIFF
--- a/app.js
+++ b/app.js
@@ -1168,6 +1168,7 @@ function closeKpiDashboard(){
 function switchToView(viewId){
     requestAnimationFrame(()=>{
         closeAllSliders();
+        if (typeof clearMainContent === 'function') clearMainContent();
         const table = document.getElementById('tableContainer');
         if(table) table.style.display = 'none';
 
@@ -1789,6 +1790,15 @@ document.addEventListener('DOMContentLoaded', function() {
             const heatmapSuccess = forceButtonClick('heatmapBtn', () => { closeWorkflowSidebar(); window.openHeatmap(); });
             if (!heatmapSuccess) {
                 console.error('RiskMap button not found!');
+            }
+
+            const riskMapBtn = document.getElementById('heatmapBtn');
+            if (riskMapBtn) {
+                riskMapBtn.addEventListener('click', () => {
+                    closeAllSliders();
+                    renderRiskMap();
+                    highlightSidebarButton('heatmapBtn');
+                });
             }
             
             const archiveSuccess = forceButtonClick('archiveBtn', () => { closeWorkflowSidebar(); window.showArchive(); });

--- a/utils.js
+++ b/utils.js
@@ -796,6 +796,9 @@ function clearMainContent() {
     if (contentArea) {
         contentArea.innerHTML = '';
     }
+
+    document.querySelectorAll('.showdata-container, #main-table-wrapper, .legacy-wrapper')
+        .forEach(el => el.remove());
 }
 
 function renderView(view) {


### PR DESCRIPTION
## Summary
- improve `clearMainContent` to remove leftover DOM elements
- ensure `switchToView` clears old views before rendering
- bind risk map button to directly open the map and highlight it

## Testing
- `npm run setup`


------
https://chatgpt.com/codex/tasks/task_e_68448844bd5483238bc9466fecfc562a