### PR TITLE
Fix KPI chart scroll container

### DIFF
--- a/app.html
+++ b/app.html
@@ -99,7 +99,11 @@
             <h2>KPI DASHBOARD</h2>
             <button id="closeKpiBtn" class="close-slider-btn">×</button>
           </div>
-          <div class="slider-content" id="kpiDashboardContent"></div>
+          <div class="slider-content" id="kpiDashboardContent">
+            <div id="kpiChartWrapper">
+              <canvas id="kpiChart"></canvas>
+            </div>
+          </div>
         </div>
     </div>
 
@@ -675,6 +679,21 @@
         #kpiDashboardContainer canvas {
             width: 100% !important;
             height: auto !important;
+        }
+
+        #kpiChartWrapper {
+            max-height: calc(100vh - 220px);
+            overflow-y: auto;
+            overflow-x: hidden;
+            padding-right: 8px;
+            margin-top: 1rem;
+            scroll-behavior: smooth;
+        }
+
+        #kpiChart {
+            width: 100%;
+            height: auto !important;
+            display: block;
         }
 
         .sidebar-slider {

--- a/app.js
+++ b/app.js
@@ -1225,9 +1225,12 @@ function renderKpiDashboard() {
     chartArea.className = 'chart-area';
 
     const chartWrap = document.createElement('div');
+    chartWrap.id = 'kpiChartWrapper';
     chartWrap.className = 'chart-container chart-scrollable';
-    chartWrap.style.height = Math.max(aggregatedData.length * 32, 300) + 'px';
-    chartWrap.innerHTML = '<canvas id="kpiChart"></canvas>';
+    chartWrap.style.maxHeight = 'calc(100vh - 220px)';
+    const kpiCanvas = document.createElement('canvas');
+    kpiCanvas.id = 'kpiChart';
+    chartWrap.appendChild(kpiCanvas);
     chartArea.appendChild(chartWrap);
 
     const historyWrap = document.createElement('div');
@@ -1260,7 +1263,7 @@ function renderKpiDashboard() {
         const metric = metricSelect.value;
         const labels = dashboardData.map(r => r['Customer Name']);
         const data = dashboardData.map(r => parseFloat(r[metric]) || 0);
-        chartWrap.style.height = Math.max(dashboardData.length * 32, 300) + 'px';
+        kpiCanvas.style.height = Math.max(dashboardData.length * 32, 300) + 'px';
         if (chart) chart.destroy();
         chart = new Chart(document.getElementById('kpiChart').getContext('2d'), {
             type: 'bar',

--- a/styles.css
+++ b/styles.css
@@ -953,3 +953,18 @@ body {
   background-color: #1a1a1a;
   box-shadow: -2px 0 10px rgba(255,210,33,0.3);
 }
+
+#kpiChartWrapper {
+  max-height: calc(100vh - 220px);
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding-right: 8px;
+  margin-top: 1rem;
+  scroll-behavior: smooth;
+}
+
+#kpiChart {
+  width: 100%;
+  height: auto !important;
+  display: block;
+}


### PR DESCRIPTION
## Summary
- add scroll wrapper for KPI chart in HTML structure
- style `#kpiChartWrapper` and `#kpiChart` for smooth scrolling
- adjust JS to use new wrapper and canvas elements
- ensure dynamic height is applied to canvas

## Testing
- `npm run setup`

------
https://chatgpt.com/codex/tasks/task_e_6844a28d2f2c83239ad9aa005b895030