### PR TITLE
Fix customer name aggregation

### DIFF
--- a/app.js
+++ b/app.js
@@ -177,7 +177,7 @@ function extractCustomerData(rawData, headers) {
         if (!grouped[key]) {
             grouped[key] = {
                 ...row,
-                'Customer Name': name || `Customer ${index + 1}`,
+                'Customer Name': name || '',
                 'Customer Number': row[numberColumn],
                 'LCSM': lcsm || 'N/A',
                 'Total Risk': risk,
@@ -189,7 +189,7 @@ function extractCustomerData(rawData, headers) {
             }
             grouped[key]['ARR'] += arr;
 
-            if (name && (!grouped[key]['Customer Name'] || name.length > grouped[key]['Customer Name'].length)) {
+            if (!grouped[key]['Customer Name'] && name) {
                 grouped[key]['Customer Name'] = name;
             }
             if (lcsm && (!grouped[key]['LCSM'] || grouped[key]['LCSM'] === 'N/A')) {
@@ -206,7 +206,13 @@ function extractCustomerData(rawData, headers) {
         });
     });
 
-    return Object.values(grouped);
+    const result = Object.values(grouped);
+    result.forEach((entry, idx) => {
+        if (!entry['Customer Name']) {
+            entry['Customer Name'] = `Customer ${idx + 1}`;
+        }
+    });
+    return result;
 }
 
 window.extractCustomerData = extractCustomerData;

--- a/tests/extractCustomerData.test.js
+++ b/tests/extractCustomerData.test.js
@@ -25,3 +25,25 @@ test('extractCustomerData aggregates by customer number', () => {
     expect(row['Total Risk']).toBe(12);
     expect(row['Customer Number']).toBe('123');
 });
+
+test('uses real customer name when available', () => {
+    const headers = ['Customer Number', 'ARR', 'Total Risk', 'Customer Name'];
+    const data = [
+        { 'Customer Number': '1', ARR: '500', 'Total Risk': '1', 'Customer Name': '' },
+        { 'Customer Number': '1', ARR: '500', 'Total Risk': '2', 'Customer Name': 'Alpha' }
+    ];
+    const result = extractCustomerData(data, headers);
+    expect(result).toHaveLength(1);
+    expect(result[0]['Customer Name']).toBe('Alpha');
+});
+
+test('falls back to placeholder when no name exists', () => {
+    const headers = ['Customer Number', 'ARR', 'Total Risk'];
+    const data = [
+        { 'Customer Number': '2', ARR: '100', 'Total Risk': '5' },
+        { 'Customer Number': '2', ARR: '200', 'Total Risk': '1' }
+    ];
+    const result = extractCustomerData(data, headers);
+    expect(result).toHaveLength(1);
+    expect(result[0]['Customer Name']).toMatch(/^Customer \d+/);
+});


### PR DESCRIPTION
## Summary
- preserve real customer names during aggregation
- assign placeholder after grouping when no name found
- test fallback logic for customer names

## Testing
- `npx eslint .`
- `npm test`
- `npm run setup`

------
https://chatgpt.com/codex/tasks/task_e_6853eb7a82dc832393ef2e52a4766022