### PR TITLE
Fix customer name fallback

### DIFF
--- a/app.js
+++ b/app.js
@@ -173,12 +173,13 @@ function extractCustomerData(rawData, headers) {
         const risk = riskColumn ? extractNumber(row[riskColumn]) : 0;
         const name = customerColumn ? row[customerColumn] : '';
         const lcsm = lcsmColumn ? row[lcsmColumn] : '';
+        const numberValue = numberColumn ? row[numberColumn] : '';
 
         if (!grouped[key]) {
             grouped[key] = {
                 ...row,
-                'Customer Name': name || '',
-                'Customer Number': row[numberColumn],
+                'Customer Name': (name && String(name).trim()) || (numberValue && String(numberValue).trim()) || '',
+                'Customer Number': numberValue,
                 'LCSM': lcsm || 'N/A',
                 'Total Risk': risk,
                 'ARR': arr
@@ -189,8 +190,8 @@ function extractCustomerData(rawData, headers) {
             }
             grouped[key]['ARR'] += arr;
 
-            if (!grouped[key]['Customer Name'] && name) {
-                grouped[key]['Customer Name'] = name;
+            if (name && (!grouped[key]['Customer Name'] || grouped[key]['Customer Name'] === String(grouped[key]['Customer Number']).trim())) {
+                grouped[key]['Customer Name'] = String(name).trim();
             }
             if (lcsm && (!grouped[key]['LCSM'] || grouped[key]['LCSM'] === 'N/A')) {
                 grouped[key]['LCSM'] = lcsm;
@@ -207,9 +208,9 @@ function extractCustomerData(rawData, headers) {
     });
 
     const result = Object.values(grouped);
-    result.forEach((entry, idx) => {
-        if (!entry['Customer Name']) {
-            entry['Customer Name'] = `Customer ${idx + 1}`;
+    result.forEach(entry => {
+        if (!entry['Customer Name'] || !String(entry['Customer Name']).trim()) {
+            entry['Customer Name'] = entry['Customer Number'] ? String(entry['Customer Number']).trim() : '';
         }
     });
     return result;

--- a/tests/extractCustomerData.test.js
+++ b/tests/extractCustomerData.test.js
@@ -37,7 +37,7 @@ test('uses real customer name when available', () => {
     expect(result[0]['Customer Name']).toBe('Alpha');
 });
 
-test('falls back to placeholder when no name exists', () => {
+test('falls back to customer number when no name exists', () => {
     const headers = ['Customer Number', 'ARR', 'Total Risk'];
     const data = [
         { 'Customer Number': '2', ARR: '100', 'Total Risk': '5' },
@@ -45,5 +45,5 @@ test('falls back to placeholder when no name exists', () => {
     ];
     const result = extractCustomerData(data, headers);
     expect(result).toHaveLength(1);
-    expect(result[0]['Customer Name']).toMatch(/^Customer \d+/);
+    expect(result[0]['Customer Name']).toBe('2');
 });


### PR DESCRIPTION
## Summary
- handle missing customer names without numeric placeholders
- expect customer number fallback in tests

## Testing
- `npm run setup`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6853ed5ee29c832384cd873347581cb7