### PR TITLE
Fix riskmap table rendering after upload

### DIFF
--- a/riskmap.html
+++ b/riskmap.html
@@ -891,9 +891,10 @@
         };
 
         // RiskMap State
-        let riskmapData = [];
+        let riskmapData = window.riskmapData || [];
         function renderRiskMap(data) {
             riskmapData = data || [];
+            window.riskmapData = riskmapData;
             updateRiskmapDisplay();
             console.log('✅ Risk Map rendered with', riskmapData.length, 'entries');
         }
@@ -1337,6 +1338,7 @@
                 const active = extractedData.filter(customer => !customer.erledigt);
                 console.log('RiskMap: Updated local data:', active.length, 'customers');
                 renderRiskMap(active);
+                updateRiskmapDisplay();
 
                 console.log('=== RiskMap File Upload SUCCESS ===');
                 showNotification(`Datei erfolgreich hochgeladen: ${extractedData.length} Kunden mit korrekten ARR-Werten verarbeitet!`);


### PR DESCRIPTION
## Summary
- keep RiskMap data globally accessible
- trigger table update when uploading data

## Testing
- `npm run setup`


------
https://chatgpt.com/codex/tasks/task_e_6853f8c3c6688323a0c85f3dd782166f